### PR TITLE
Add Terraform modules for S3 and DynamoDB

### DIFF
--- a/create_s3/main.tf
+++ b/create_s3/main.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}

--- a/create_s3/main.tf
+++ b/create_s3/main.tf
@@ -1,4 +1,0 @@
-resource "aws_s3_bucket" "this" {
-  bucket = var.bucket_name
-  tags   = var.tags
-}

--- a/modules/create_dynamodb/main.tf
+++ b/modules/create_dynamodb/main.tf
@@ -1,0 +1,12 @@
+resource "aws_dynamodb_table" "this" {
+  name         = var.table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = var.hash_key
+
+  attribute {
+    name = var.hash_key
+    type = "S"
+  }
+
+  tags = var.tags
+}

--- a/modules/create_dynamodb/outputs.tf
+++ b/modules/create_dynamodb/outputs.tf
@@ -1,0 +1,7 @@
+output "table_name" {
+  value = aws_dynamodb_table.this.name
+}
+
+output "table_arn" {
+  value = aws_dynamodb_table.this.arn
+}

--- a/modules/create_dynamodb/variables.tf
+++ b/modules/create_dynamodb/variables.tf
@@ -1,0 +1,14 @@
+variable "table_name" {
+  type        = string
+  description = "Name of the DynamoDB table"
+}
+
+variable "hash_key" {
+  type        = string
+  description = "Partition key for the DynamoDB table"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+}

--- a/modules/create_s3/main.tf
+++ b/modules/create_s3/main.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}

--- a/modules/create_s3/outputs.tf
+++ b/modules/create_s3/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.this.arn
+}

--- a/modules/create_s3/variables.tf
+++ b/modules/create_s3/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This PR adds reusable Terraform modules:
- create_s3: for S3 bucket creation
- create_dynamodb: for DynamoDB table creation
